### PR TITLE
add SVector and MVector constructorof without type params

### DIFF
--- a/src/staticarrays.jl
+++ b/src/staticarrays.jl
@@ -1,20 +1,19 @@
 using .StaticArrays
 
-struct SArrayConstructor{S,N,L} end
-struct MArrayConstructor{S,N,L} end
+struct SArrayConstructor{S} end
+struct MArrayConstructor{S} end
 struct SizedArrayConstructor{S,N,M} end
 
-(::SArrayConstructor{S,N,L})(data::NTuple{L,T}) where {S,T,N,L} = SArray{S,T,N,L}(data)
-(::MArrayConstructor{S,N,L})(data::NTuple{L,T}) where {S,T,N,L} = MArray{S,T,N,L}(data)
+(::SArrayConstructor{S})(args...) where {S} = SArray{S}(args...)
+(::MArrayConstructor{S})(args...) where {S} = MArray{S}(args...)
 (::SizedArrayConstructor{S,N,M})(data::AbstractArray{T,M}) where {S,T,N,M} = 
     SizedArray{S,T,N,M}(data)
 
-ConstructionBase.constructorof(sa::Type{<:SArray{S,<:Any,N,L}}) where {S,N,L} = 
-    SArrayConstructor{S,N,L}()
-ConstructionBase.constructorof(sa::Type{<:MArray{S,<:Any,N,L}}) where {S,N,L} = 
-    MArrayConstructor{S,N,L}()
+ConstructionBase.constructorof(sa::Type{<:SArray{S}}) where {S} = SArrayConstructor{S}()
+ConstructionBase.constructorof(sa::Type{<:MArray{S}}) where {S} = MArrayConstructor{S}()
 ConstructionBase.constructorof(sa::Type{<:SizedArray{S,<:Any,N,M}}) where {S,N,M} = 
     SizedArrayConstructor{S,N,M}()
 
+# static vectors don't even need the explicit size specification
 ConstructionBase.constructorof(::Type{SVector}) = SVector
 ConstructionBase.constructorof(::Type{MVector}) = MVector

--- a/src/staticarrays.jl
+++ b/src/staticarrays.jl
@@ -5,5 +5,5 @@ ConstructionBase.constructorof(sa::Type{<:MArray{S}}) where {S} = MArray{S}
 ConstructionBase.constructorof(sa::Type{<:SizedArray{S}}) where {S} = SizedArray{S}
 
 # static vectors don't even need the explicit size specification
-ConstructionBase.constructorof(::Type{SVector}) = SVector
-ConstructionBase.constructorof(::Type{MVector}) = MVector
+ConstructionBase.constructorof(::Type{<:SVector}) = SVector
+ConstructionBase.constructorof(::Type{<:MVector}) = MVector

--- a/src/staticarrays.jl
+++ b/src/staticarrays.jl
@@ -1,18 +1,8 @@
 using StaticArraysCore
 
-struct SArrayConstructor{S} end
-struct MArrayConstructor{S} end
-struct SizedArrayConstructor{S,N,M} end
-
-(::SArrayConstructor{S})(args...) where {S} = SArray{S}(args...)
-(::MArrayConstructor{S})(args...) where {S} = MArray{S}(args...)
-(::SizedArrayConstructor{S,N,M})(data::AbstractArray{T,M}) where {S,T,N,M} = 
-    SizedArray{S,T,N,M}(data)
-
-ConstructionBase.constructorof(sa::Type{<:SArray{S}}) where {S} = SArrayConstructor{S}()
-ConstructionBase.constructorof(sa::Type{<:MArray{S}}) where {S} = MArrayConstructor{S}()
-ConstructionBase.constructorof(sa::Type{<:SizedArray{S,<:Any,N,M}}) where {S,N,M} = 
-    SizedArrayConstructor{S,N,M}()
+ConstructionBase.constructorof(sa::Type{<:SArray{S}}) where {S} = SArray{S}
+ConstructionBase.constructorof(sa::Type{<:MArray{S}}) where {S} = MArray{S}
+ConstructionBase.constructorof(sa::Type{<:SizedArray{S}}) where {S} = SizedArray{S}
 
 # static vectors don't even need the explicit size specification
 ConstructionBase.constructorof(::Type{SVector}) = SVector

--- a/src/staticarrays.jl
+++ b/src/staticarrays.jl
@@ -15,3 +15,6 @@ ConstructionBase.constructorof(sa::Type{<:MArray{S,<:Any,N,L}}) where {S,N,L} =
     MArrayConstructor{S,N,L}()
 ConstructionBase.constructorof(sa::Type{<:SizedArray{S,<:Any,N,M}}) where {S,N,M} = 
     SizedArrayConstructor{S,N,M}()
+
+ConstructionBase.constructorof(::Type{SVector}) = SVector
+ConstructionBase.constructorof(::Type{MVector}) = MVector

--- a/test/staticarrays.jl
+++ b/test/staticarrays.jl
@@ -18,8 +18,11 @@ using ConstructionBaseExtras, StaticArrays, Test, ConstructionBase
     for T in (SVector, MVector)
         @test ConstructionBase.constructorof(T)((1, 2, 3))::T == T((1, 2, 3))
         @test ConstructionBase.constructorof(T{3})((1, 2, 3))::T == T((1, 2, 3))
+        @test ConstructionBase.constructorof(T{3})((1, 2))::T == T((1, 2))
         @test ConstructionBase.constructorof(T{3, Symbol})((1, 2, 3))::T == T((1, 2, 3))
+        @test ConstructionBase.constructorof(T{3, Symbol})((1, 2))::T == T((1, 2))
         @test ConstructionBase.constructorof(T{3, X} where {X})((1, 2, 3))::T == T((1, 2, 3))
-        @test_broken ConstructionBase.constructorof(T{X, Symbol} where {X})((1, 2, 3))::T == T((1, 2, 3))
+        @test ConstructionBase.constructorof(T{3, X} where {X})((1, 2))::T == T((1, 2))
+        @test ConstructionBase.constructorof(T{X, Symbol} where {X})((1, 2, 3))::T == T((1, 2, 3))
     end
 end

--- a/test/staticarrays.jl
+++ b/test/staticarrays.jl
@@ -14,4 +14,12 @@ using ConstructionBaseExtras, StaticArrays, Test, ConstructionBase
     sz2 = ConstructionBase.constructorof(typeof(sz))([:a :b; :c :d]) 
     @test sz2 == SizedArray{Tuple{2,2}}([:a :b; :c :d])
     @test typeof(sz2) <: SizedArray{Tuple{2,2},Symbol,2,2}
+
+    for T in (SVector, MVector)
+        @test ConstructionBase.constructorof(T)((1, 2, 3))::T == T((1, 2, 3))
+        @test ConstructionBase.constructorof(T{3})((1, 2, 3))::T == T((1, 2, 3))
+        @test ConstructionBase.constructorof(T{3, Symbol})((1, 2, 3))::T == T((1, 2, 3))
+        @test ConstructionBase.constructorof(T{3, X} where {X})((1, 2, 3))::T == T((1, 2, 3))
+        @test_broken ConstructionBase.constructorof(T{X, Symbol} where {X})((1, 2, 3))::T == T((1, 2, 3))
+    end
 end


### PR DESCRIPTION
Vectors are special: they can be constructed without knowing any type parameters, unlike higher-dim arrays.

Only the first added test is actually "new". Others worked before as well, here just making sure they stay fine.