### PR TITLE
StaticArraysCore instead of Requires

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,9 +13,8 @@ jobs:
       fail-fast: true
       matrix:
         version:
-          - '1.0'
-          - '1.3'
-          - '1.5'
+          - '1.6'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,16 @@
 name = "ConstructionBaseExtras"
 uuid = "914cd950-b775-4282-9f32-54fc4544c321"
-
 authors = ["Rafael Schouten"]
 version = "0.1.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [compat]
-julia = "1"
-Requires = "1"
 ConstructionBase = "1"
+StaticArraysCore = "1"
+julia = "1.6"
 
 [extras]
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/src/ConstructionBaseExtras.jl
+++ b/src/ConstructionBaseExtras.jl
@@ -1,11 +1,7 @@
 module ConstructionBaseExtras
 
-using ConstructionBase, Requires
+using ConstructionBase
 
-function __init__()
-    @require StaticArrays="90137ffa-7385-5640-81b9-e52037218182" begin
-        include("staticarrays.jl")
-    end
-end
+include("staticarrays.jl")
 
 end

--- a/src/staticarrays.jl
+++ b/src/staticarrays.jl
@@ -1,4 +1,4 @@
-using .StaticArrays
+using StaticArraysCore
 
 struct SArrayConstructor{S,N,L} end
 struct MArrayConstructor{S,N,L} end


### PR DESCRIPTION
No need for `Requires` given the recent split of core types into `StaticArraysCore`.